### PR TITLE
wraps returned dataframe in CallResult

### DIFF
--- a/PcafeaturesD3MWrapper/wrapper.py
+++ b/PcafeaturesD3MWrapper/wrapper.py
@@ -98,7 +98,7 @@ class pcafeatures(PrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
             by their contribution to the first principal component, and scores in
             the second column.
         """
-        return PCAFeatures().rank_features(inputs = inputs)
+        return CallResult(PCAFeatures().rank_features(inputs = inputs))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By contract, `produce` calls should wrap returned values in the `CallResult` type.